### PR TITLE
Implement simple share target Whisper PWA

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>M4A Transcriber</title>
+  <link rel="manifest" href="manifest.json">
+</head>
+<body>
+  <h1>M4A Transcriber</h1>
+  <p>Share an audio file with this app to transcribe it using OpenAI Whisper.</p>
+  <script src="index.js"></script>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -1,0 +1,32 @@
+// index.js
+// Replace with your OpenAI API key
+const OPENAI_API_KEY = 'YOUR_OPENAI_API_KEY';
+
+if ('serviceWorker' in navigator) {
+  navigator.serviceWorker.register('/sw.js');
+}
+
+window.addEventListener('load', async () => {
+  if (!location.search.includes('share')) return;
+
+  const cache = await caches.open('incoming');
+  const resp = await cache.match('latest-audio');
+  if (!resp) {
+    document.body.innerText = 'No audio file found';
+    return;
+  }
+  const file = await resp.blob();
+  await cache.delete('latest-audio');
+
+  const fd = new FormData();
+  fd.append('model', 'whisper-1');
+  fd.append('file', file, 'recording.m4a');
+
+  const transcription = await fetch('https://api.openai.com/v1/audio/transcriptions', {
+    method: 'POST',
+    headers: { 'Authorization': `Bearer ${OPENAI_API_KEY}` },
+    body: fd,
+  }).then(r => r.json()).catch(err => ({ error: err.toString() }));
+
+  document.body.innerText = transcription.text || transcription.error || 'No speech detected';
+});

--- a/manifest.json
+++ b/manifest.json
@@ -1,19 +1,19 @@
-/* manifest.json */
 {
   "name": "M4A Transcriber",
   "start_url": "/",
   "display": "standalone",
-  "icons": [ /* … */ ],
-
+  "icons": [],
   "share_target": {
     "action": "/receive/",
-    "method": "POST",           // binary → POST
+    "method": "POST",
     "enctype": "multipart/form-data",
     "params": {
-      "files": [{
-        "name": "audio",        // the field name your SW will read
-        "accept": ["audio/m4a", "audio/mp4", "audio/*"]
-      }]
+      "files": [
+        {
+          "name": "audio",
+          "accept": ["audio/m4a", "audio/mp4", "audio/*"]
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary
- add `index.html` that registers the service worker and links the JS
- add `index.js` to retrieve shared audio and send it to the Whisper API
- clean up `manifest.json` for a valid share target

## Testing
- `python3 -m json.tool manifest.json | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_6841fbc5f3ac8324b2e7aaf74c0467f1