### PR TITLE
Mobile UX redesign

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,8 @@
         "@ffmpeg/ffmpeg": "^0.12.15",
         "@ffmpeg/util": "^0.12.2",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@types/react": "^18.2.35",
@@ -826,6 +827,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2224,6 +2234,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/readdirp": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@ffmpeg/ffmpeg": "^0.12.15",
     "@ffmpeg/util": "^0.12.2",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.30.1"
   }
 }

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+
+interface HistoryEntry {
+  id: string;
+  filename: string;
+  text: string;
+  date: string;
+}
+
+interface Props {
+  history: HistoryEntry[];
+  deleteHistory: (id: string) => void;
+}
+
+export default function History({ history, deleteHistory }: Props) {
+  if (history.length === 0) {
+    return <p className="empty">No history yet.</p>;
+  }
+  return (
+    <div className="history page">
+      {history.map((entry) => (
+        <div className="history-entry" key={entry.id}>
+          <div className="history-meta">
+            <strong>{entry.filename}</strong>
+            <span>{new Date(entry.date).toLocaleString()}</span>
+          </div>
+          <textarea readOnly rows={4} value={entry.text}></textarea>
+          <div className="actions">
+            <button onClick={() => navigator.clipboard.writeText(entry.text)}>Copy</button>
+            <button onClick={() => deleteHistory(entry.id)}>Delete</button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+interface Props {
+  sharedFile: File | null;
+  setSharedFile: (f: File | null) => void;
+  file: File | null;
+  setFile: (f: File | null) => void;
+  transcribe: () => void;
+  transcribing: boolean;
+  status: string;
+  statusType: 'info' | 'loading' | 'success' | 'error';
+  transcription: string;
+}
+
+export default function Home({
+  sharedFile,
+  setSharedFile,
+  file,
+  setFile,
+  transcribe,
+  transcribing,
+  status,
+  statusType,
+  transcription,
+}: Props) {
+  const copyOutput = () => {
+    if (transcription) navigator.clipboard.writeText(transcription);
+  };
+  const shareOutput = async () => {
+    if (navigator.share && transcription) {
+      await navigator.share({ text: transcription });
+    } else {
+      copyOutput();
+    }
+  };
+  return (
+    <div className="home page">
+      {!sharedFile && (
+        <>
+          <button className="file-button">
+            <label htmlFor="audioFile">Select Audio File</label>
+            <input
+              type="file"
+              id="audioFile"
+              accept="audio/*,.m4a"
+              onChange={(e) => setFile(e.target.files ? e.target.files[0] : null)}
+            />
+          </button>
+          {file && <p className="filename">{file.name}</p>}
+        </>
+      )}
+      {sharedFile && (
+        <div id="sharedFileInfo">
+          <p>
+            <strong>Shared file:</strong> {sharedFile.name} ({(sharedFile.size / 1024).toFixed(1)} KB)
+          </p>
+          <button onClick={() => setSharedFile(null)}>Change</button>
+        </div>
+      )}
+      <button className="primary" onClick={transcribe} disabled={transcribing || !(sharedFile || file)}>
+        {transcribing ? 'Transcribing…' : 'Transcribe'}
+      </button>
+      <div className={`status ${statusType}`}>{status}</div>
+      {transcription && (
+        <div className="output">
+          <textarea readOnly rows={10} value={transcription}></textarea>
+          <div className="actions">
+            <button onClick={copyOutput}>Copy</button>
+            <button onClick={shareOutput}>Share</button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/Onboarding.tsx
+++ b/src/pages/Onboarding.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+interface Props {
+  apiKey: string;
+  setApiKey: (k: string) => void;
+  saveKey: () => void;
+  apiKeyStatus: string;
+}
+
+export default function Onboarding({ apiKey, setApiKey, saveKey, apiKeyStatus }: Props) {
+  return (
+    <div className="onboarding">
+      <h1>Whisper Share</h1>
+      <p>Enter your OpenAI API key to continue.</p>
+      <input
+        type="password"
+        value={apiKey}
+        onChange={(e) => setApiKey(e.target.value)}
+        placeholder="OpenAI API Key"
+      />
+      <button onClick={saveKey}>Save &amp; Continue</button>
+      <p className="status-message">{apiKeyStatus}</p>
+    </div>
+  );
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface Props {
+  apiKey: string;
+  setApiKey: (k: string) => void;
+  saveKey: () => void;
+}
+
+export default function Settings({ apiKey, setApiKey, saveKey }: Props) {
+  const removeKey = () => {
+    setApiKey('');
+    localStorage.removeItem('openai_api_key_transcriber');
+  };
+  return (
+    <div className="settings page">
+      <h2>API Key</h2>
+      <input
+        type="password"
+        value={apiKey}
+        onChange={(e) => setApiKey(e.target.value)}
+        placeholder="OpenAI API Key"
+      />
+      <button onClick={saveKey}>Save</button>
+      <button onClick={removeKey}>Remove</button>
+      <h2>About</h2>
+      <p>Whisper Share lets you transcribe audio using OpenAI.</p>
+    </div>
+  );
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/style.css
+++ b/style.css
@@ -3,22 +3,19 @@ body {
     Arial, sans-serif;
   line-height: 1.6;
   margin: 0;
-  padding: 20px;
+  padding: 10px;
   background-color: #f4f4f4;
   color: #333;
-  display: flex;
-  justify-content: center;
-  align-items: flex-start;
   min-height: 100vh;
 }
 
 .container {
   background-color: #fff;
-  padding: 25px;
+  padding: 20px;
   border-radius: 8px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
-  width: 100%;
   max-width: 700px;
+  margin: auto;
 }
 
 h1,
@@ -55,6 +52,27 @@ textarea {
 
 input[type="file"] {
   padding: 3px; /* Specific styling for file input */
+}
+
+.file-button {
+  position: relative;
+  overflow: hidden;
+  display: inline-block;
+  padding: 15px 20px;
+  background-color: #007bff;
+  color: #fff;
+  border-radius: 4px;
+  margin-bottom: 10px;
+}
+
+.file-button input[type="file"] {
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  cursor: pointer;
 }
 
 button {
@@ -119,6 +137,31 @@ button:disabled {
   color: #007bff;
 }
 
+.page {
+  margin-bottom: 70px;
+}
+
+.tabbar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  justify-content: space-around;
+  background: #fff;
+  border-top: 1px solid #ddd;
+  padding: 10px 0;
+}
+
+.tabbar a {
+  color: #007bff;
+  text-decoration: none;
+}
+
+.tabbar a.active {
+  font-weight: bold;
+}
+
 /* Small screen adjustments */
 @media (max-width: 600px) {
   .container {
@@ -150,4 +193,22 @@ button:disabled {
 }
 #sharedFileInfo button:hover {
   background-color: #5a6268;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background-color: #222;
+    color: #eee;
+  }
+  .container {
+    background-color: #333;
+    color: #eee;
+  }
+  .tabbar {
+    background: #333;
+    border-top-color: #444;
+  }
+  .tabbar a {
+    color: #89b4ff;
+  }
 }


### PR DESCRIPTION
## Summary
- add onboarding, home, history and settings pages
- switch to React Router navigation with bottom tab bar
- add dark mode and responsive styling
- support sharing, copying and removing history entries

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68441aad8c1483248dc132a0f1612d36