### PR TITLE
Add share button to history entries

### DIFF
--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -27,6 +27,11 @@ const History: React.FC<HistoryProps> = ({ history, onCopy, onDelete }) => {
           <textarea readOnly rows={4} value={entry.text}></textarea>
           <div className="history-actions">
             <button onClick={() => onCopy(entry.text)}>Copy</button>
+            {navigator.share && (
+              <button onClick={() => navigator.share({ text: entry.text })}>
+                Share
+              </button>
+            )}
             <button onClick={() => onDelete(entry.id)}>Delete</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- show a Share button for each history item when the Web Share API is available

## Testing
- `npm test` *(fails: `Error: no test specified`)*

------
https://chatgpt.com/codex/tasks/task_e_68442d08073c8324a0f24afe9fb47467