### PR TITLE
Fix API key onboarding UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ export default function App() {
   const [tab, setTab] = useState<Tab>('home');
   const [apiKey, setApiKey] = useState('');
   const [apiKeyStatus, setApiKeyStatus] = useState('');
+  const [apiKeySaved, setApiKeySaved] = useState(false);
   const [status, setStatus] = useState('');
   const [statusType, setStatusType] = useState<'info' | 'loading' | 'success' | 'error'>('info');
   const [transcription, setTranscription] = useState('');
@@ -44,8 +45,10 @@ export default function App() {
     const key = localStorage.getItem(OPENAI_API_KEY_STORAGE_KEY) || '';
     setApiKey(key);
     if (key) {
+      setApiKeySaved(true);
       setApiKeyStatus('API Key loaded from storage.');
     } else {
+      setApiKeySaved(false);
       setApiKeyStatus('API Key not set. Please enter and save.');
     }
 
@@ -315,9 +318,11 @@ export default function App() {
     if (apiKey.trim()) {
       localStorage.setItem(OPENAI_API_KEY_STORAGE_KEY, apiKey.trim());
       setApiKeyStatus('API Key saved successfully!');
+      setApiKeySaved(true);
     } else {
       setApiKeyStatus('Please enter an API Key.');
       localStorage.removeItem(OPENAI_API_KEY_STORAGE_KEY);
+      setApiKeySaved(false);
     }
   }
 
@@ -333,6 +338,7 @@ export default function App() {
             apiKey={apiKey}
             setApiKey={setApiKey}
             apiKeyStatus={apiKeyStatus}
+            apiKeySaved={apiKeySaved}
             saveKey={saveKey}
             file={file}
             setFile={setFile}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,6 +4,7 @@ interface HomeProps {
   apiKey: string;
   setApiKey: (k: string) => void;
   apiKeyStatus: string;
+  apiKeySaved: boolean;
   saveKey: () => void;
   file: File | null;
   setFile: (f: File | null) => void;
@@ -20,6 +21,7 @@ const Home: React.FC<HomeProps> = ({
   apiKey,
   setApiKey,
   apiKeyStatus,
+  apiKeySaved,
   saveKey,
   file,
   setFile,
@@ -35,7 +37,7 @@ const Home: React.FC<HomeProps> = ({
 
   return (
     <div className="home-page">
-      {!apiKey && (
+      {!apiKeySaved && (
         <div className="onboarding-card">
           <h2>Welcome to Whisper Share</h2>
           <p>Enter your OpenAI API Key to get started.</p>
@@ -50,7 +52,7 @@ const Home: React.FC<HomeProps> = ({
           <div className="status-message">{apiKeyStatus}</div>
         </div>
       )}
-      {apiKey && (
+      {apiKeySaved && (
         <>
           <div className="file-card">
             {!sharedFile ? (


### PR DESCRIPTION
## Summary
- keep onboarding dialog visible until the key is saved

## Testing
- `npm install`
- `npm run build`
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_68442e574b2c8324abbd9c9957337b6d