### PR TITLE
Fix onboarding disappearing when typing API key

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -40,6 +40,7 @@ type Tab = 'home' | 'history' | 'settings';
 export default function App() {
   const [tab, setTab] = useState<Tab>('home');
   const [apiKey, setApiKey] = useState('');
+  const [apiKeySaved, setApiKeySaved] = useState(false);
   const [apiKeyStatus, setApiKeyStatus] = useState('');
   const [status, setStatus] = useState('');
   const [statusType, setStatusType] = useState<'info' | 'loading' | 'success' | 'error'>('info');
@@ -56,8 +57,10 @@ export default function App() {
     setApiKey(key);
     if (key) {
       setApiKeyStatus('API Key loaded from storage.');
+      setApiKeySaved(true);
     } else {
       setApiKeyStatus('API Key not set. Please enter and save.');
+      setApiKeySaved(false);
     }
 
     try {
@@ -326,9 +329,11 @@ export default function App() {
     if (apiKey.trim()) {
       localStorage.setItem(OPENAI_API_KEY_STORAGE_KEY, apiKey.trim());
       setApiKeyStatus('API Key saved successfully!');
+      setApiKeySaved(true);
     } else {
       setApiKeyStatus('Please enter an API Key.');
       localStorage.removeItem(OPENAI_API_KEY_STORAGE_KEY);
+      setApiKeySaved(false);
     }
   }
 
@@ -347,6 +352,7 @@ export default function App() {
           <Home
             apiKey={apiKey}
             setApiKey={setApiKey}
+            apiKeySaved={apiKeySaved}
             apiKeyStatus={apiKeyStatus}
             saveKey={saveKey}
             file={file}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -13,6 +13,7 @@ import {
 interface HomeProps {
   apiKey: string;
   setApiKey: (k: string) => void;
+  apiKeySaved: boolean;
   apiKeyStatus: string;
   saveKey: () => void;
   file: File | null;
@@ -29,6 +30,7 @@ interface HomeProps {
 const Home: React.FC<HomeProps> = ({
   apiKey,
   setApiKey,
+  apiKeySaved,
   apiKeyStatus,
   saveKey,
   file,
@@ -52,7 +54,7 @@ const Home: React.FC<HomeProps> = ({
 
   return (
     <Box className="home-page">
-      {!apiKey && (
+      {!apiKeySaved && (
         <Card className="onboarding-card">
           <CardContent>
             <Typography variant="h5" gutterBottom>
@@ -79,7 +81,7 @@ const Home: React.FC<HomeProps> = ({
           </CardContent>
         </Card>
       )}
-      {apiKey && (
+      {apiKeySaved && (
         <>
           <Card className="file-card" sx={{ mb: 2 }}>
             <CardContent>


### PR DESCRIPTION
## Summary
- store if API key has been saved in localStorage
- show onboarding card until the key is saved

## Testing
- `npx tsc --noEmit`
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68442f256210832498e3edf6f64cfd1b